### PR TITLE
bugfix util_get_attribute_surrogate

### DIFF
--- a/src/OM_TAPIGEN.pkb
+++ b/src/OM_TAPIGEN.pkb
@@ -345,6 +345,8 @@ CREATE OR REPLACE PACKAGE BODY om_tapigen IS
                    'TO_CLOB(''@@@@@@@@@@@@@@@'')'
                   WHEN p_data_type = 'BLOB' THEN
                    'TO_BLOB(UTL_RAW.cast_to_raw(''@@@@@@@@@@@@@@@''))'
+                  WHEN p_data_type = 'RAW' THEN
+                   'UTL_RAW.cast_to_raw(''@@@@@@@@@@@@@@@'')' 
                   WHEN p_data_type = 'XMLTYPE' THEN
                    'XMLTYPE(''<NULL/>'')'
                   ELSE


### PR DESCRIPTION
This is a small fix for the API to make it work correctly with RAW Datatypes. 

Without the fix, Primary Keys of Type RAW (sys_guid()) are not working as RAW cannot be compared to VARCHAR2.